### PR TITLE
Fix camera Up axis

### DIFF
--- a/src/gcode.ts
+++ b/src/gcode.ts
@@ -177,6 +177,7 @@ export class GCodeRenderer {
 
     private newCamera(width: number, height: number) {
         const camera = new PerspectiveCamera(75, width / height, 0.1, 1000)
+        camera.up.set(0, 0, 1)
         
         if (this.cameraControl) {
             this.cameraControl.dispose()


### PR DESCRIPTION
Hi, I found a few minor annoyances while tinkering with your otherwise excellent library. This attempts to fix one of them, I'll keep the merge requests coming if you're interested ;)

It seems that Three.js [sets the wrong "up" axis for CAD-based files](https://stackoverflow.com/questions/23096896/how-to-change-the-up-axis-in-orbitcontrol), so the rotation of the model is a bit awkward when displaying a gcode. This seems to fix the issue for not just GoSlice, but also for Cura and PrusaSlicer, possibly more.