### PR TITLE
Improve extrusion radius calculation in parser

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -348,16 +348,17 @@ export class GCodeParser {
           const length = getLength(lastPoint, newPoint);
 
           if (length !== 0) {
-            let radius = ((e - lastE) / length) * 10;
+            let radiusSquared = ((e - lastE) / length);
 
+            let radius = 0;
             // Hide negative extrusions as only move-extrusions
-            if (radius < 0) {
+            if (radiusSquared < 0) {
               radius = 0;
             }
-
-            if (radius == 0) {
+            if (radiusSquared === 0) {
               radius = travelWidth;
             } else {
+              radius = Math.sqrt(radiusSquared);
               // Update the bounding box.
               const { min: newMin, max: newMax } = calcMinMax(
                 min,


### PR DESCRIPTION
Refactored the calculation of the extrusion radius by introducing `radiusSquared` to handle squared values correctly before taking the square root. This change ensures that negative extrusions are handled as move-extrusions and updates bounding box calculations more accurately. Previously the code produced weird results for thicker rafts.