### PR TITLE
Add support for multi extruder nozzle offsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,17 @@ However, If the user wants layers to be taken from the comments of the Gcode suc
 renderer.layerType = LayerType.LAYER_COMMENTS;
 ```
 
+### Configure nozzle offsets for dual extrusion
+
+If you have a dual extruder printer the gcode paths for the second extruder may be offset. To correctly render the paths you can set the nozzle offsets:
+
+```js
+renderer.nozzleOffsets = [
+  new gcodeViewer.Vector2(0, 0),
+  new gcodeViewer.Vector2(10, 10),
+]
+```
+
 ### Access three.js
 
 Both, the scene and the whole three.js is exported, so you can use it.  

--- a/src/gcode.ts
+++ b/src/gcode.ts
@@ -9,6 +9,7 @@ import {
   AmbientLight,
   SpotLight,
   MeshPhongMaterial,
+  Vector2,
 } from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
 import { GCodeParser, LayerDefinition, LayerType } from "./parser";
@@ -71,6 +72,25 @@ export class GCodeRenderer {
     this.parser.travelWidth = w;
   }
 
+
+  /**
+   * Nozzle offsets for multi-extrusion.
+   * 
+   * @type Vector2[]
+   */
+  public get nozzleOffsets(): Vector2[] {
+    return this.parser.nozzleOffsets;
+  }
+
+  /**
+   * Nozzle offsets for multi-extrusion.
+   * 
+   * @type Vector2[]
+   */
+  public set nozzleOffsets(nozzleOffsets: Vector2[]) {
+    this.parser.nozzleOffsets = nozzleOffsets;
+  }
+  
   /**
    * Type to determine how the layer change is detected.
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export * from "./gcode";
 export * from "./SegmentColorizer";
-export { Color } from "three";
+export { Color, Vector2 } from "three";
 export * as THREE from "three";


### PR DESCRIPTION
I would like to render toolpaths for a multi-extruder printer. When generating gcode the offset between the nozzles is taken into account by baking this offset into the gcode. When rendering gcode these offsets should be added to the extrusion lines in order for a correct view of the gcode.